### PR TITLE
Migration to new PyPI package name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,10 @@
 DeprecationWarning
 ==================
 
-This package has been migrated to ``meta_exc`` on PyPI and will no longer be pip 
-installable through ``pip install exc`` after 2019-06-17. Please update your codebase
-to use ``pip install meta_exc``.
+This package was available under ``exc`` on PyPI and has undergone a recent
+migration to ``meta_exc``. It will no longer be available to be installed via
+``pip install exc`` after 2019-06-17. Please update your codebase to use 
+``pip install meta_exc``.
 
 The exc package
 ===============

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@ DeprecationWarning
 ==================
 
 This package has been migrated to meta-exc on PyPI and will no longer be pip 
-installable through `pip install exc` after 2019-06-17. Please update your codebase
-to use `pip install meta-exc`.
+installable through ``pip install exc`` after 2019-06-17. Please update your codebase
+to use ``pip install meta-exc``.
 
 The exc package
 ===============

--- a/README.rst
+++ b/README.rst
@@ -1,20 +1,20 @@
 DeprecationWarning
 ==================
 
-This package has been migrated to meta-exc on PyPI and will no longer be pip 
+This package has been migrated to ``meta_exc`` on PyPI and will no longer be pip 
 installable through ``pip install exc`` after 2019-06-17. Please update your codebase
-to use ``pip install meta-exc``.
+to use ``pip install meta_exc``.
 
 The exc package
 ===============
 
-The ``exc`` package provides a metaclass for exceptions, allowing
+The ``meta_exc`` package provides a metaclass for exceptions, allowing
 on-the-spot subclassing, e.g. in order to have one exception class per
 raise site. It is easy to use, as the following example illustrates ::
 
-    import exc
+    import meta_exc
 
-    class FruitError(exc.Exception):
+    class FruitError(meta_exc.Exception):
         pass
 
     import sys
@@ -31,11 +31,11 @@ raise site. It is easy to use, as the following example illustrates ::
     except FruitError:
         print('I did not eat the fruit for some reason.')
 
-There are wrapped versions of all the builtins: ``exc.TypeError``,
-``exc.IOError`` and so forth. The metaclass is called
+There are wrapped versions of all the builtins: ``meta_exc.TypeError``,
+``meta_exc.IOError`` and so forth. The metaclass is called
 ``DerivableException``.
 
-The intended usage of ``exc`` is for each exception site to raise an
+The intended usage of ``meta_exc`` is for each exception site to raise an
 exception with a unique class, so that they may be caught
 individually.
 
@@ -43,15 +43,15 @@ individually.
 Shorthand syntax
 ================
 
-``exc.Exception['a/b'] == exc.Exception.specialize('a/b') == exc.Exception.specialize('a').specialize('b')``
+``meta_exc.Exception['a/b'] == meta_exc.Exception.specialize('a/b') == meta_exc.Exception.specialize('a').specialize('b')``
 
 Compatibility
 =============
 
-``exc`` should work with Python >= 2.6 and Python >= 3. It does not
+``meta_exc`` should work with Python >= 2.6 and Python >= 3. It does not
 work in Python 2.4 because of limitations on exception types. In
 Python 3, try/except does not consult instancehook or subclasshook, so
-``exc.Exception`` cannot be used to catch plain ``Exception`` (but it
+``meta_exc.Exception`` cannot be used to catch plain ``Exception`` (but it
 can be in Python 2).
 
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+DeprecationWarning
+==================
+
+This package has been migrated to meta-exc on PyPI and will no longer be pip 
+installable through `pip install exc` after 2019-06-17. Please update your codebase
+to use `pip install meta-exc`.
 
 The exc package
 ===============

--- a/meta_exc/__init__.py
+++ b/meta_exc/__init__.py
@@ -1,8 +1,11 @@
+import warnings
 
 try:
     import builtins
 except ImportError:
     import __builtin__ as builtins
+
+warnings.warn("Package migrated to meta-exc", DeprecationWarning)
 
 
 class DerivableException(type):

--- a/meta_exc/__init__.py
+++ b/meta_exc/__init__.py
@@ -1,11 +1,7 @@
-import warnings
-
 try:
     import builtins
 except ImportError:
     import __builtin__ as builtins
-
-warnings.warn("Package migrated to meta-exc", DeprecationWarning)
 
 
 class DerivableException(type):

--- a/meta_exc/test.py
+++ b/meta_exc/test.py
@@ -1,5 +1,5 @@
 
-import exc as E
+import meta_exc as E
 
 ExcA = E.IOError["A"]
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup
 
 setup(
-    name = 'exc',
+    name = 'meta_exc',
     version = '0.91',
-    packages = ['exc'],
+    packages = ['meta_exc'],
     
     # Metadata
     author = 'Olivier Breuleux',


### PR DESCRIPTION
@breuleux - I called everything `meta_exc` for the new package name just to throw something out there but let me know what you want and I will change it before merge. 